### PR TITLE
[Fix] 1.1.1 빌드버전 - 버그 수정

### DIFF
--- a/TodayDiary.xcodeproj/project.pbxproj
+++ b/TodayDiary.xcodeproj/project.pbxproj
@@ -460,7 +460,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayseong.TodayDiary;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -502,7 +502,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayseong.TodayDiary;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/TodayDiary.xcodeproj/project.pbxproj
+++ b/TodayDiary.xcodeproj/project.pbxproj
@@ -460,7 +460,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayseong.TodayDiary;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -502,7 +502,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.jayseong.TodayDiary;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/TodayDiary/Controllers/AccessManager.swift
+++ b/TodayDiary/Controllers/AccessManager.swift
@@ -11,6 +11,7 @@ class AccessManager {
     static let shared = AccessManager()
     private init() {}
     
+    // iCloud 설정 되어 있는지 확인
     func checkICloudAccountStatus(completion: @escaping (Bool) -> Void) {
         CKContainer.default().accountStatus { accountStatus, error in
             if accountStatus == .available {

--- a/TodayDiary/Controllers/CoreDataManager.swift
+++ b/TodayDiary/Controllers/CoreDataManager.swift
@@ -321,7 +321,6 @@ class CoreDataManager {
     // MARK: - AccountInfo Entity Methods
     func fetchIsRegistered() {
         isRegistered = loadIsRegistered()
-        print("isRegistered: \(isRegistered)")
     }
 
     func loadIsRegistered() -> Int? {
@@ -331,8 +330,7 @@ class CoreDataManager {
             let results = try context.fetch(fetchRequest)
                      
             for result in results {
-                if let isRegistered = result.value(forKey: "isRegistered") as? Bool {
-                    print("isRegistered date: \(isRegistered)")
+                if let isRegistered = result.value(forKey: "isRegistered") as? Int {
                     return 1
                 }
             }

--- a/TodayDiary/Controllers/CoreDataManager.swift
+++ b/TodayDiary/Controllers/CoreDataManager.swift
@@ -12,28 +12,19 @@ import WidgetKit
 class CoreDataManager {
     static let shared = CoreDataManager()
     var isRegistered: Int?
-    private let appGroup = "group.jayseong.TodayDiary"
-
+    
     lazy var persistentContainer: NSPersistentCloudKitContainer = {
-        
-        guard let url = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.jayseong.TodayDiary") else { fatalError("Shared file container could not be created.") }
-        
-        let storeURL = url.appending(path: "TodayDiary.sqlite")
-        let storeDescription = NSPersistentStoreDescription(url: storeURL)
-        storeDescription.cloudKitContainerOptions = NSPersistentCloudKitContainerOptions(containerIdentifier: "iCloud.com.jayseong.TodayDiary")
-        
-        let container = NSPersistentCloudKitContainer(name: "TodayDiary")
-        container.persistentStoreDescriptions = [storeDescription]
-        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
-            if let error = error as NSError? {
-                fatalError("Unresolved error \(error), \(error.userInfo)")
-            }
-            // 충돌 해결 정책 및 자동 병합 설정
-            container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
-            container.viewContext.automaticallyMergesChangesFromParent = true
-        })
-        return container
-    }()
+            let container = NSPersistentCloudKitContainer(name: "TodayDiary")
+            container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+                if let error = error as NSError? {
+                    fatalError("Unresolved error \(error), \(error.userInfo)")
+                }
+                // 충돌 해결 정책 및 자동 병합 설정
+                container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+                container.viewContext.automaticallyMergesChangesFromParent = true
+            })
+            return container
+        }()
 
     var context: NSManagedObjectContext {
         return persistentContainer.viewContext

--- a/TodayDiary/Controllers/CoreDataManager.swift
+++ b/TodayDiary/Controllers/CoreDataManager.swift
@@ -362,20 +362,38 @@ class CoreDataManager {
         print("true 로 저장 성공")
     }
     
-    func deleteIsRegistered() {
-        let entityNames = context.persistentStoreCoordinator?.managedObjectModel.entities.compactMap { $0.name } ?? []
+    func loadAllRegistered() {
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "AccountInfo")
         do {
-            for entityName in entityNames {
-                let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
-                let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
-                
-                // Execute batch delete
-                try context.execute(deleteRequest)
+            let results = try context.fetch(fetchRequest)
+            for result in results {
+                if let accountInfo = result as? NSManagedObject {
+                }
+            }
+        } catch {
+            print("데이터 가져오기 실패: \(error)")
+        }
+    }
+    
+    func deleteAllData() {
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "Diary")
+        
+        if let results = try? context.fetch(fetchRequest) as? [NSManagedObject] {
+            for object in results {
+                context.delete(object)
             }
             saveContext()
-            print("IsRegistered 가 성공적으로 삭제되었습니다.")
-        } catch {
-            print("IsRegistered를 삭제하는 중 오류 발생: \(error.localizedDescription)")
+        }
+    }
+    
+    func deleteIsRegistered() {
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "AccountInfo")
+        
+        if let results = try? context.fetch(fetchRequest) as? [NSManagedObject] {
+            for object in results {
+                context.delete(object)
+            }
+            saveContext()
         }
     }
 

--- a/TodayDiary/Controllers/DiaryMainViewController.swift
+++ b/TodayDiary/Controllers/DiaryMainViewController.swift
@@ -74,6 +74,8 @@ class DiaryMainViewController: UIViewController {
         // 위젯 업데이트
         WidgetData.shared.isLogin = AccessManager.shared.loadUserIDFromKeychain() != nil ? true : false
         WidgetCenter.shared.reloadTimelines(ofKind: "DiaryWidget")
+        
+        CoreDataManager.shared.loadAllRegistered()
     }
     
     deinit {

--- a/TodayDiary/Controllers/DiaryMainViewController.swift
+++ b/TodayDiary/Controllers/DiaryMainViewController.swift
@@ -189,11 +189,6 @@ extension DiaryMainViewController: FSCalendarDelegate, FSCalendarDataSource, FSC
             cell.setCalendarCellData(_date: date, _emoji: emoji, _text: text, _uuid: uuid!)
         }
         
-        
-//        if data.0 != nil {
-//            cell.setCalendarCellData(_date: data.0!, _emoji: data.1, _text: data.2, _uuid: data.3!)
-//        }
-        
         cell.setCalendarCellDesign(monthPosition: position, date: date)
         return cell
     }

--- a/TodayDiary/Controllers/SecessionViewController.swift
+++ b/TodayDiary/Controllers/SecessionViewController.swift
@@ -140,27 +140,6 @@ class SecessionViewController: UIViewController {
         self.present(popVC, animated: false, completion: nil)
     }
     
-    // 회원 탈퇴 시에만 수행해야함
-    // 모든 데이터 삭제
-    func deleteAllData() {
-        let entityNames = CoreDataManager.shared.context .persistentStoreCoordinator?.managedObjectModel.entities.compactMap { $0.name } ?? []
-        do {
-            for entityName in entityNames {
-                let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
-                let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
-                
-                // Execute batch delete
-                try CoreDataManager.shared.context.execute(deleteRequest)
-            }
-            
-            // Save context after deletion
-            try CoreDataManager.shared.context.save()
-            print("모든 데이터가 성공적으로 삭제되었습니다.")
-        } catch {
-            print("모든 데이터를 삭제하는 중 오류 발생: \(error.localizedDescription)")
-        }
-    }
-    
     func setNavigationBar() {
         navigationController?.interactivePopGestureRecognizer?.delegate = nil
         navigationItem.title = "회원탈퇴"

--- a/TodayDiary/Controllers/SecessionViewController.swift
+++ b/TodayDiary/Controllers/SecessionViewController.swift
@@ -104,7 +104,7 @@ class SecessionViewController: UIViewController {
         // 클로저 전달
         // 최종 탈퇴 확인버튼 누를시 해당 함수 실행
         popVC.onAcceptAction = {
-            self.deleteAllData()
+            CoreDataManager.shared.deleteAllData()
             CoreDataManager.shared.deleteIsRegistered()
             
             let transitionView = UIView(frame: UIScreen.main.bounds)


### PR DESCRIPTION
## ✨작업내용
1. AppGroup 생성 후 CloudKit 과 Coredata 간의 데이터 연동이 안되던 버그 해결
2. 기기 여러개인 경우 회원탈퇴 시 데이터 연동이 안되던 오류 해결


## ✨고민한 내용
### AppGroup 생성 후 CloudKit 과 Coredata 간의 데이터 연동이 안되던 버그 해결
Widget 생성을 위한 데이터 공유용 AppGroup 을 생성했었는데 CloudKit 이라 

### 기기 여러개인 경우 회원탈퇴 시 데이터 연동이 안되던 오류 해결

```
func deleteAllData() {
        let entityNames = context.persistentStoreCoordinator?.managedObjectModel.entities.compactMap { $0.name } ?? []
        do {
            for entityName in entityNames {
                let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
                let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
                try context.execute(deleteRequest)
            }
            saveContext()
            print("모든 데이터가 성공적으로 삭제되었습니다.")
        } catch {
            print("모든 데이터를 삭제하는 중 오류 발생: \(error.localizedDescription)")
        }
    }
```
데이터를 삭제할 때 위 코드를 사용하고 있었는데
A,B 기기에서 같은 계정을 사용하는 경우에, B기기에서 deleteAllData 를 호출해 모든 데이터를 삭제하는 기능을 수행한다면
B 기기에서는 데이터가 잘 삭제되어 있지만 A 기기에서는 삭제되지 않는 버그를 발견했습니다

위 방식이 아닌 아래 코드로 바꾸어주니 기기가 여러개이더라도 데이터 삭제 후 잘 연동되는 것을 확인했습니다

```
func deleteAllData() {
        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "Diary")
        
        if let results = try? context.fetch(fetchRequest) as? [NSManagedObject] {
            for object in results {
                context.delete(object)
            }
            saveContext()
        }
    }
```